### PR TITLE
fix module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "module": "dist/v2-sdk.esm.js",
+  "module": "dist/v1-sdk.esm.js",
   "scripts": {
     "lint": "tsdx lint src test",
     "build": "tsdx build",


### PR DESCRIPTION
Currently, the "module" is referencing a file that does not exist. This can lead to errors in bundlers when attempting to import the module.

![2025-02-04_11-03](https://github.com/user-attachments/assets/b16798fd-3a39-4456-81b9-ebe9949b862c)
